### PR TITLE
Fix payload search results to get score first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Search result payload to add score first and remove non needed parameters.
+
+### Fixed
+
 - **Upload Documents status code parity**: Upload now returns `201` for new documents and `200` when overwriting an existing document, matching Azure AI Search behavior.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Search result payload to add score first and remove non needed parameters.
+- **Search response parity**: Removed `@search.coverage` unless `minimumCoverage` is set. Moved `@search.score` before document fields. Replaced `NaN` scores with `1.0` for wildcard/filter-only searches.
+- **Highlight parity**: Only highlight fields specified in the `highlight` parameter. `@search.highlights` now appears after `@search.score`, before document fields.
+- **Filters on searchable+filterable fields**: `search.in()` and `eq` filters now work on fields that are both `searchable` and `filterable` (e.g., `category`).
+- **Double range filters**: Filters like `rating ge 4.0` now correctly use double range queries for `Edm.Double`/`Edm.Single` fields.
+- **Merge operations**: Fixed `merge` and `mergeOrUpload` actions being treated as `upload` due to `JsonElement` deserialization, which replaced entire documents instead of merging fields.
 
 ### Fixed
 

--- a/src/AzureAISearchSimulator.Core/Models/IndexDocuments.cs
+++ b/src/AzureAISearchSimulator.Core/Models/IndexDocuments.cs
@@ -27,16 +27,28 @@ public class IndexAction : Dictionary<string, object?>
     {
         get
         {
-            if (TryGetValue("@search.action", out var action) && action is string actionStr)
+            if (TryGetValue("@search.action", out var action))
             {
-                return actionStr.ToLowerInvariant() switch
+                // Handle both string and JsonElement (System.Text.Json deserializes
+                // Dictionary<string, object?> values as JsonElement, not string)
+                var actionStr = action switch
                 {
-                    "upload" => IndexActionType.Upload,
-                    "merge" => IndexActionType.Merge,
-                    "mergeorupload" => IndexActionType.MergeOrUpload,
-                    "delete" => IndexActionType.Delete,
-                    _ => IndexActionType.Upload
+                    string s => s,
+                    System.Text.Json.JsonElement je when je.ValueKind == System.Text.Json.JsonValueKind.String => je.GetString(),
+                    _ => null
                 };
+
+                if (actionStr != null)
+                {
+                    return actionStr.ToLowerInvariant() switch
+                    {
+                        "upload" => IndexActionType.Upload,
+                        "merge" => IndexActionType.Merge,
+                        "mergeorupload" => IndexActionType.MergeOrUpload,
+                        "delete" => IndexActionType.Delete,
+                        _ => IndexActionType.Upload
+                    };
+                }
             }
             return IndexActionType.Upload; // Default action
         }

--- a/src/AzureAISearchSimulator.Search/LuceneDocumentMapper.cs
+++ b/src/AzureAISearchSimulator.Search/LuceneDocumentMapper.cs
@@ -163,6 +163,18 @@ public static class LuceneDocumentMapper
         {
             // Searchable - use TextField for full-text search (analyzer handles normalization)
             fields.Add(new TextField(field.Name, strValue, field.Retrievable != false ? Field.Store.YES : Field.Store.NO));
+
+            // If also filterable, add exact-match StringField so filter queries work
+            // (TextField lowercases via analyzer; filters need exact case matching)
+            if (field.Filterable == true)
+            {
+                fields.Add(new StringField(field.Name, normalizedValue, Field.Store.NO));
+            }
+
+            if (field.Sortable == true)
+            {
+                fields.Add(new SortedDocValuesField(field.Name, new BytesRef(normalizedValue)));
+            }
         }
         else if (field.Filterable == true || field.Sortable == true)
         {

--- a/src/AzureAISearchSimulator.Search/SearchService.cs
+++ b/src/AzureAISearchSimulator.Search/SearchService.cs
@@ -217,6 +217,10 @@ public class SearchService : ISearchService
         {
             var luceneDoc = docId >= 0 ? searcher.Doc(docId) : null;
             var searchResult = new SearchResult();
+
+            // Set score first to match Azure property ordering (@search.score before document fields)
+            // Replace NaN with 1.0 (occurs when Lucene uses sorted search without scoring, e.g. wildcard/filter queries)
+            searchResult.Score = double.IsNaN(score) ? 1.0 : score;
             
             if (luceneDoc != null)
             {
@@ -226,8 +230,6 @@ public class SearchService : ISearchService
                     searchResult[kvp.Key] = kvp.Value;
                 }
             }
-            
-            searchResult.Score = score;
             
             // Add highlights if requested
             if (textQuery != null && request.Highlight != null && luceneDoc != null)
@@ -273,8 +275,11 @@ public class SearchService : ISearchService
             }
         }
 
-        // Search coverage (always 100% for simulator)
-        response.SearchCoverage = 100.0;
+        // Search coverage - only include when minimumCoverage is specified (Azure behavior)
+        if (request.MinimumCoverage.HasValue)
+        {
+            response.SearchCoverage = 100.0;
+        }
 
         // Finalize debug info
         totalStopwatch.Stop();
@@ -674,7 +679,24 @@ public class SearchService : ISearchService
 
     private Query BuildNumericRangeQuery(string fieldName, string op, string value, string edmType)
     {
-        // For simplicity, convert all to long range queries
+        // Handle double/single types
+        if (edmType.Equals("edm.double", StringComparison.OrdinalIgnoreCase) ||
+            edmType.Equals("edm.single", StringComparison.OrdinalIgnoreCase))
+        {
+            if (double.TryParse(value, System.Globalization.CultureInfo.InvariantCulture, out var doubleValue))
+            {
+                return op switch
+                {
+                    "gt" => NumericRangeQuery.NewDoubleRange(fieldName, doubleValue, double.MaxValue, false, true),
+                    "ge" => NumericRangeQuery.NewDoubleRange(fieldName, doubleValue, double.MaxValue, true, true),
+                    "lt" => NumericRangeQuery.NewDoubleRange(fieldName, double.MinValue, doubleValue, true, false),
+                    "le" => NumericRangeQuery.NewDoubleRange(fieldName, double.MinValue, doubleValue, true, true),
+                    _ => new MatchAllDocsQuery()
+                };
+            }
+        }
+
+        // Handle integer types
         if (long.TryParse(value, out var longValue))
         {
             return op switch
@@ -683,6 +705,20 @@ public class SearchService : ISearchService
                 "ge" => NumericRangeQuery.NewInt64Range(fieldName, longValue, long.MaxValue, true, true),
                 "lt" => NumericRangeQuery.NewInt64Range(fieldName, long.MinValue, longValue - 1, true, true),
                 "le" => NumericRangeQuery.NewInt64Range(fieldName, long.MinValue, longValue, true, true),
+                _ => new MatchAllDocsQuery()
+            };
+        }
+
+        // Fallback: try parsing as double even for non-double types (e.g. "4.0" on an int field)
+        if (double.TryParse(value, System.Globalization.CultureInfo.InvariantCulture, out var fallbackDouble))
+        {
+            var fallbackLong = (long)fallbackDouble;
+            return op switch
+            {
+                "gt" => NumericRangeQuery.NewInt64Range(fieldName, fallbackLong + 1, long.MaxValue, true, true),
+                "ge" => NumericRangeQuery.NewInt64Range(fieldName, fallbackLong, long.MaxValue, true, true),
+                "lt" => NumericRangeQuery.NewInt64Range(fieldName, long.MinValue, fallbackLong - 1, true, true),
+                "le" => NumericRangeQuery.NewInt64Range(fieldName, long.MinValue, fallbackLong, true, true),
                 _ => new MatchAllDocsQuery()
             };
         }

--- a/tests/AzureAISearchSimulator.Core.Tests/SearchHighlightTests.cs
+++ b/tests/AzureAISearchSimulator.Core.Tests/SearchHighlightTests.cs
@@ -1,0 +1,244 @@
+using AzureAISearchSimulator.Core.Models;
+using AzureAISearchSimulator.Core.Services;
+using AzureAISearchSimulator.Search;
+using AzureAISearchSimulator.Search.Hnsw;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using AzureAISearchSimulator.Core.Configuration;
+using Moq;
+
+namespace AzureAISearchSimulator.Core.Tests;
+
+/// <summary>
+/// Tests for search highlight parity with Azure AI Search:
+/// - Only requested fields are highlighted (not all searchable fields)
+/// - @search.highlights appears before document fields in results
+/// - Multiple highlight fields can be specified comma-separated
+/// </summary>
+public class SearchHighlightTests : IDisposable
+{
+    private readonly string _testDir;
+    private readonly LuceneIndexManager _luceneManager;
+    private readonly DocumentService _documentService;
+    private readonly SearchService _searchService;
+    private readonly SearchIndex _testIndex;
+
+    public SearchHighlightTests()
+    {
+        _testDir = Path.Combine(Path.GetTempPath(), "highlight-tests", Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_testDir);
+
+        var luceneSettings = Options.Create(new LuceneSettings { IndexPath = _testDir });
+        _luceneManager = new LuceneIndexManager(
+            Mock.Of<ILogger<LuceneIndexManager>>(),
+            luceneSettings);
+
+        var vectorSearchService = Mock.Of<IVectorSearchService>();
+
+        _testIndex = new SearchIndex
+        {
+            Name = "highlight-test",
+            Fields = new List<SearchField>
+            {
+                new() { Name = "id", Type = "Edm.String", Key = true },
+                new() { Name = "title", Type = "Edm.String", Searchable = true },
+                new() { Name = "description", Type = "Edm.String", Searchable = true },
+                new() { Name = "category", Type = "Edm.String", Searchable = true, Filterable = true }
+            }
+        };
+
+        var indexServiceMock = new Mock<IIndexService>();
+        indexServiceMock.Setup(x => x.GetIndexAsync("highlight-test", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_testIndex);
+
+        _documentService = new DocumentService(
+            Mock.Of<ILogger<DocumentService>>(),
+            _luceneManager,
+            vectorSearchService,
+            indexServiceMock.Object);
+
+        _searchService = new SearchService(
+            Mock.Of<ILogger<SearchService>>(),
+            _luceneManager,
+            vectorSearchService,
+            indexServiceMock.Object);
+
+        // Seed documents
+        var upload = new IndexDocumentsRequest
+        {
+            Value = new List<IndexAction>
+            {
+                CreateAction("upload", new Dictionary<string, object?>
+                {
+                    ["id"] = "1",
+                    ["title"] = "Luxury Spa Resort",
+                    ["description"] = "A beautiful spa with luxury amenities and a relaxing pool.",
+                    ["category"] = "Luxury"
+                }),
+                CreateAction("upload", new Dictionary<string, object?>
+                {
+                    ["id"] = "2",
+                    ["title"] = "Budget Hotel",
+                    ["description"] = "Affordable rooms for travelers looking for comfort.",
+                    ["category"] = "Budget"
+                })
+            }
+        };
+        _documentService.IndexDocumentsAsync("highlight-test", upload).GetAwaiter().GetResult();
+    }
+
+    public void Dispose()
+    {
+        _luceneManager.Dispose();
+        if (Directory.Exists(_testDir))
+        {
+            try { Directory.Delete(_testDir, true); } catch { }
+        }
+    }
+
+    private static IndexAction CreateAction(string actionType, Dictionary<string, object?> fields)
+    {
+        var action = new IndexAction { ["@search.action"] = actionType };
+        foreach (var kvp in fields)
+            action[kvp.Key] = kvp.Value;
+        return action;
+    }
+
+    // ─── Highlight field restriction tests ─────────────────────────
+
+    [Fact]
+    public async Task Highlight_OnlyRequestedField_IsHighlighted()
+    {
+        var request = new SearchRequest
+        {
+            Search = "luxury spa",
+            Highlight = "description",
+            HighlightPreTag = "<em>",
+            HighlightPostTag = "</em>",
+            Top = 10
+        };
+
+        var response = await _searchService.SearchAsync("highlight-test", request);
+
+        var result = response.Value.First(r => r.ContainsKey("id") && r["id"]?.ToString() == "1");
+        Assert.NotNull(result.Highlights);
+
+        // Only "description" should be highlighted, not "title" or "category"
+        Assert.True(result.Highlights.ContainsKey("description"));
+        Assert.False(result.Highlights.ContainsKey("title"));
+        Assert.False(result.Highlights.ContainsKey("category"));
+    }
+
+    [Fact]
+    public async Task Highlight_MultipleFields_OnlyRequestedFieldsHighlighted()
+    {
+        var request = new SearchRequest
+        {
+            Search = "luxury",
+            Highlight = "title,description",
+            HighlightPreTag = "<b>",
+            HighlightPostTag = "</b>",
+            Top = 10
+        };
+
+        var response = await _searchService.SearchAsync("highlight-test", request);
+
+        var result = response.Value.First(r => r.ContainsKey("id") && r["id"]?.ToString() == "1");
+        Assert.NotNull(result.Highlights);
+
+        // "category" contains "Luxury" but was NOT requested for highlighting
+        Assert.False(result.Highlights.ContainsKey("category"));
+    }
+
+    [Fact]
+    public async Task Highlight_FieldWithNoMatch_IsOmitted()
+    {
+        // Search for "pool" — only doc 1 has it, and only in description
+        var request = new SearchRequest
+        {
+            Search = "pool",
+            Highlight = "title",
+            HighlightPreTag = "<em>",
+            HighlightPostTag = "</em>",
+            Top = 10
+        };
+
+        var response = await _searchService.SearchAsync("highlight-test", request);
+
+        // Doc 1 matches "pool" in description, but we asked for title highlights only
+        var result = response.Value.FirstOrDefault(r => r.ContainsKey("id") && r["id"]?.ToString() == "1");
+        Assert.NotNull(result);
+        // title doesn't contain "pool", so no highlights should be present
+        Assert.True(result.Highlights == null || !result.Highlights.ContainsKey("title"));
+    }
+
+    [Fact]
+    public async Task Highlight_UsesCustomPrePostTags()
+    {
+        var request = new SearchRequest
+        {
+            Search = "spa",
+            Highlight = "description",
+            HighlightPreTag = "<<START>>",
+            HighlightPostTag = "<<END>>",
+            Top = 10
+        };
+
+        var response = await _searchService.SearchAsync("highlight-test", request);
+
+        var result = response.Value.First(r => r.ContainsKey("id") && r["id"]?.ToString() == "1");
+        Assert.NotNull(result.Highlights);
+        Assert.True(result.Highlights.ContainsKey("description"));
+
+        var fragment = result.Highlights["description"][0];
+        Assert.Contains("<<START>>", fragment);
+        Assert.Contains("<<END>>", fragment);
+        Assert.DoesNotContain("<em>", fragment);
+    }
+
+    // ─── Property ordering tests ──────────────────────────────────
+
+    [Fact]
+    public async Task Highlight_PropertyOrder_ScoreThenHighlightsThenFields()
+    {
+        var request = new SearchRequest
+        {
+            Search = "spa",
+            Highlight = "description",
+            HighlightPreTag = "<em>",
+            HighlightPostTag = "</em>",
+            Top = 10
+        };
+
+        var response = await _searchService.SearchAsync("highlight-test", request);
+
+        var result = response.Value.First(r => r.ContainsKey("id") && r["id"]?.ToString() == "1");
+        var keys = result.Keys.ToList();
+
+        var scoreIndex = keys.IndexOf("@search.score");
+        var highlightsIndex = keys.IndexOf("@search.highlights");
+        var firstDocField = keys.FindIndex(k => !k.StartsWith("@search."));
+
+        // @search.score should be first
+        Assert.Equal(0, scoreIndex);
+        // @search.highlights should be before document fields
+        Assert.True(highlightsIndex < firstDocField,
+            $"@search.highlights (index {highlightsIndex}) should come before first document field (index {firstDocField})");
+    }
+
+    [Fact]
+    public async Task NoHighlight_NoSearchHighlightsProperty()
+    {
+        var request = new SearchRequest
+        {
+            Search = "luxury",
+            Top = 10
+        };
+
+        var response = await _searchService.SearchAsync("highlight-test", request);
+
+        var result = response.Value.First();
+        Assert.Null(result.Highlights);
+        Assert.False(result.ContainsKey("@search.highlights"));
+    }
+}


### PR DESCRIPTION
# Description

<!-- Provide a clear and concise description of your changes -->
Fix payload search results to get score first

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration change
- [ ] ♻️ Refactoring (no functional changes)

## Related Issue

<!-- Link to the issue this PR addresses (if applicable) -->
<!-- Fixes #(issue) -->

## Azure AI Search Reference

<!-- If applicable, link to the official Azure AI Search documentation -->
<!-- https://learn.microsoft.com/en-us/azure/search/ -->

## Checklist

<!-- Mark completed items with an "x" -->

### Code Quality

- [x] My code follows the [coding standards](../CONTRIBUTING.md#coding-standards) of this project
- [x] I have used meaningful names for variables, methods, and classes
- [x] I have kept methods small and focused (single responsibility)
- [x] I have used async/await for I/O operations where appropriate

### Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have run `dotnet test` and all tests pass

### Documentation

- [ ] I have updated the documentation as needed
- [ ] I have added XML documentation for new public APIs
- [x] I have updated the CHANGELOG.md if applicable

### General

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
