### PR TITLE
Fixing phrase search highlight

### DIFF
--- a/src/AzureAISearchSimulator.Search/SearchService.cs
+++ b/src/AzureAISearchSimulator.Search/SearchService.cs
@@ -1088,7 +1088,10 @@ public class SearchService : ISearchService
                 
                 if (fragments.Length > 0)
                 {
-                    highlights[field.Name] = fragments.ToList();
+                    // Merge adjacent highlight tags: "<em>word1</em> <em>word2</em>" → "<em>word1 word2</em>"
+                    highlights[field.Name] = fragments
+                        .Select(f => MergeAdjacentHighlightTags(f, preTag, postTag))
+                        .ToList();
                 }
             }
         }
@@ -1098,6 +1101,19 @@ public class SearchService : ISearchService
         }
 
         return highlights;
+    }
+
+    /// <summary>
+    /// Merges adjacent highlight tags so that consecutive highlighted terms form a single span.
+    /// E.g. "<em>beautiful</em> <em>spa</em>" becomes "<em>beautiful spa</em>".
+    /// </summary>
+    private static string MergeAdjacentHighlightTags(string fragment, string preTag, string postTag)
+    {
+        // Replace occurrences of "postTag whitespace preTag" with just the whitespace
+        var pattern = System.Text.RegularExpressions.Regex.Escape(postTag)
+            + @"(\s+)"
+            + System.Text.RegularExpressions.Regex.Escape(preTag);
+        return System.Text.RegularExpressions.Regex.Replace(fragment, pattern, "$1");
     }
 
     public async Task<SuggestResponse> SuggestAsync(string indexName, SuggestRequest request)

--- a/tests/AzureAISearchSimulator.Core.Tests/SearchHighlightTests.cs
+++ b/tests/AzureAISearchSimulator.Core.Tests/SearchHighlightTests.cs
@@ -243,4 +243,92 @@ public class SearchHighlightTests : IDisposable
         Assert.Null(result.Highlights);
         Assert.False(result.ContainsKey("@search.highlights"));
     }
+
+    // ─── Phrase search tests ──────────────────────────────────────
+
+    [Fact]
+    public async Task PhraseSearch_ExactMatch_ReturnsMatchingDocWithHighlights()
+    {
+        // Phrase search: "luxury spa" should only match doc 1 (title = "Luxury Spa Resort")
+        var request = new SearchRequest
+        {
+            Search = "\"luxury spa\"",
+            Highlight = "title,description",
+            HighlightPreTag = "<em>",
+            HighlightPostTag = "</em>",
+            Top = 10
+        };
+
+        var response = await _searchService.SearchAsync("highlight-test", request);
+
+        // Only doc 1 contains the exact phrase "luxury spa"
+        Assert.Single(response.Value);
+        var result = response.Value[0];
+        Assert.Equal("1", result["id"]?.ToString());
+
+        // Highlights should be present and contain the phrase as one contiguous span
+        Assert.NotNull(result.Highlights);
+        Assert.True(result.Highlights.ContainsKey("title"));
+        var titleHighlight = result.Highlights["title"][0];
+        Assert.Contains("<em>Luxury Spa</em>", titleHighlight);
+
+        // Description has "spa" and "luxury" but NOT adjacent as "luxury spa",
+        // so phrase query should NOT highlight the description
+        Assert.False(result.Highlights.ContainsKey("description"));
+    }
+
+    [Fact]
+    public async Task PhraseSearch_WordsNotAdjacent_ReturnsEmpty()
+    {
+        // "affordable spa" — no document has these words adjacent in this order
+        var request = new SearchRequest
+        {
+            Search = "\"affordable spa\"",
+            Top = 10
+        };
+
+        var response = await _searchService.SearchAsync("highlight-test", request);
+
+        Assert.Empty(response.Value);
+    }
+
+    [Fact]
+    public async Task PhraseSearch_VsNonPhrase_ReturnsDifferentResults()
+    {
+        // Non-phrase: "luxury spa" (without quotes) matches both docs
+        // because "luxury" appears in doc 1 title/description and doc 2 doesn't,
+        // but the OR semantics may match broadly.
+        var nonPhraseRequest = new SearchRequest
+        {
+            Search = "beautiful spa",
+            Top = 10
+        };
+        var nonPhraseResponse = await _searchService.SearchAsync("highlight-test", nonPhraseRequest);
+
+        // Phrase: "beautiful spa" (with quotes) must match only doc 1
+        // where "beautiful spa" appears adjacent in description
+        var phraseRequest = new SearchRequest
+        {
+            Search = "\"beautiful spa\"",
+            Highlight = "description",
+            HighlightPreTag = "<em>",
+            HighlightPostTag = "</em>",
+            Top = 10
+        };
+        var phraseResponse = await _searchService.SearchAsync("highlight-test", phraseRequest);
+
+        // Non-phrase should return more results (OR of "beautiful" and "spa")
+        Assert.True(nonPhraseResponse.Value.Count >= phraseResponse.Value.Count);
+
+        // Phrase should return exactly doc 1 (description = "A beautiful spa with...")
+        Assert.Single(phraseResponse.Value);
+        Assert.Equal("1", phraseResponse.Value[0]["id"]?.ToString());
+
+        // Highlight should wrap the entire phrase as one contiguous span
+        var result = phraseResponse.Value[0];
+        Assert.NotNull(result.Highlights);
+        Assert.True(result.Highlights.ContainsKey("description"));
+        var fragment = result.Highlights["description"][0];
+        Assert.Contains("<em>beautiful spa</em>", fragment);
+    }
 }


### PR DESCRIPTION
# Description

<!-- Provide a clear and concise description of your changes -->
Fixing phrase search highlight

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration change
- [ ] ♻️ Refactoring (no functional changes)

## Related Issue

<!-- Link to the issue this PR addresses (if applicable) -->
<!-- Fixes #(issue) -->
Search = "\"beautiful spa\""
should return:
<em>beautiful spa</em>

## Azure AI Search Reference

<!-- If applicable, link to the official Azure AI Search documentation -->
<!-- https://learn.microsoft.com/en-us/azure/search/ -->

## Checklist

<!-- Mark completed items with an "x" -->

### Code Quality

- [x] My code follows the [coding standards](../CONTRIBUTING.md#coding-standards) of this project
- [x] I have used meaningful names for variables, methods, and classes
- [x] I have kept methods small and focused (single responsibility)
- [x] I have used async/await for I/O operations where appropriate

### Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run `dotnet test` and all tests pass

### Documentation

- [x] I have updated the documentation as needed
- [x] I have added XML documentation for new public APIs
- [x] I have updated the CHANGELOG.md if applicable

### General

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
