### PR TITLE
Fixing custom separator in search.in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,7 +97,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Search response parity**: Removed `@search.coverage` unless `minimumCoverage` is set. Moved `@search.score` before document fields. Replaced `NaN` scores with `1.0` for wildcard/filter-only searches.
 - **Highlight parity**: Only highlight fields specified in the `highlight` parameter. `@search.highlights` now appears after `@search.score`, before document fields.
-- **Filters on searchable+filterable fields**: `search.in()` and `eq` filters now work on fields that are both `searchable` and `filterable` (e.g., `category`).
+- **Filters on searchable+filterable fields**: `search.in()` and `eq` filters now work on fields that are both `searchable` and `filterable` (e.g., `category`), and `search.in()` now supports the optional third delimiter argument (for example: `search.in(category, 'Luxury|Resort|Boutique', '|')`).
 - **Double range filters**: Filters like `rating ge 4.0` now correctly use double range queries for `Edm.Double`/`Edm.Single` fields.
 - **Merge operations**: Fixed `merge` and `mergeOrUpload` actions being treated as `upload` due to `JsonElement` deserialization, which replaced entire documents instead of merging fields.
 

--- a/src/AzureAISearchSimulator.Search/SearchService.cs
+++ b/src/AzureAISearchSimulator.Search/SearchService.cs
@@ -824,14 +824,21 @@ public class SearchService : ISearchService
             }
         }
 
-        // Handle search.in(field, 'val1,val2,val3')
+        // Handle search.in(field, 'val1,val2,val3') and search.in(field, 'val1|val2', '|')
         var searchInMatch = System.Text.RegularExpressions.Regex.Match(
-            expression, @"search\.in\((\w+),\s*'([^']*)'\)", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+            expression,
+            @"search\.in\((\w+)\s*,\s*'([^']*)'(?:\s*,\s*'([^']*)')?\s*\)",
+            System.Text.RegularExpressions.RegexOptions.IgnoreCase);
         
         if (searchInMatch.Success)
         {
             var fieldName = searchInMatch.Groups[1].Value;
-            var values = searchInMatch.Groups[2].Value.Split(',', StringSplitOptions.RemoveEmptyEntries);
+            var valueList = searchInMatch.Groups[2].Value;
+            var delimiter = searchInMatch.Groups[3].Success ? searchInMatch.Groups[3].Value : ",";
+
+            var values = delimiter.Length == 0
+                ? new[] { valueList }
+                : valueList.Split(delimiter.ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
             
             var luceneFieldName = ResolveFilterFieldName(schema, fieldName);
             var boolQuery = new BooleanQuery();

--- a/tests/AzureAISearchSimulator.Integration.Tests/SearchInFilterIntegrationTests.cs
+++ b/tests/AzureAISearchSimulator.Integration.Tests/SearchInFilterIntegrationTests.cs
@@ -1,0 +1,163 @@
+using Xunit;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using AzureAISearchSimulator.Core.Configuration;
+using AzureAISearchSimulator.Core.Models;
+using AzureAISearchSimulator.Core.Services;
+using AzureAISearchSimulator.Search;
+using AzureAISearchSimulator.Search.Hnsw;
+
+namespace AzureAISearchSimulator.Integration.Tests;
+
+public class SearchInFilterIntegrationTests : IDisposable
+{
+    private readonly string _testDir;
+    private readonly LuceneIndexManager _luceneManager;
+    private readonly Mock<IIndexService> _indexServiceMock;
+    private readonly DocumentService _documentService;
+    private readonly SearchService _searchService;
+
+    public SearchInFilterIntegrationTests()
+    {
+        _testDir = Path.Combine(Path.GetTempPath(), "search-in-filter-tests", Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_testDir);
+
+        var luceneSettings = Options.Create(new LuceneSettings { IndexPath = _testDir });
+        _luceneManager = new LuceneIndexManager(
+            Mock.Of<ILogger<LuceneIndexManager>>(),
+            luceneSettings);
+
+        _indexServiceMock = new Mock<IIndexService>();
+
+        var scoringProfileService = new ScoringProfileService(
+            Mock.Of<ILogger<ScoringProfileService>>());
+
+        _documentService = new DocumentService(
+            Mock.Of<ILogger<DocumentService>>(),
+            _luceneManager,
+            Mock.Of<IVectorSearchService>(),
+            _indexServiceMock.Object);
+
+        _searchService = new SearchService(
+            Mock.Of<ILogger<SearchService>>(),
+            _luceneManager,
+            Mock.Of<IVectorSearchService>(),
+            _indexServiceMock.Object,
+            Mock.Of<ISynonymMapResolver>(),
+            scoringProfileService);
+    }
+
+    private void RegisterIndex(SearchIndex index)
+    {
+        _indexServiceMock.Setup(x => x.GetIndexAsync(index.Name, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(index);
+        _luceneManager.GetWriter(index.Name);
+    }
+
+    private async Task UploadDocuments(string indexName, params Dictionary<string, object?>[] documents)
+    {
+        var request = new IndexDocumentsRequest
+        {
+            Value = documents.Select(doc =>
+            {
+                var action = new IndexAction { ["@search.action"] = "upload" };
+                foreach (var kvp in doc)
+                {
+                    action[kvp.Key] = kvp.Value;
+                }
+                return action;
+            }).ToList()
+        };
+
+        await _documentService.IndexDocumentsAsync(indexName, request);
+    }
+
+    private static SearchIndex CreateCategoryIndex(string indexName)
+    {
+        return new SearchIndex
+        {
+            Name = indexName,
+            Fields = new List<SearchField>
+            {
+                new() { Name = "id", Type = "Edm.String", Key = true },
+                new() { Name = "hotelName", Type = "Edm.String", Searchable = true },
+                new() { Name = "category", Type = "Edm.String", Searchable = true, Filterable = true }
+            }
+        };
+    }
+
+    [Fact]
+    public async Task Filter_SearchIn_WithDefaultCommaDelimiter_ReturnsMatchingDocuments()
+    {
+        var indexName = $"searchin-comma-{Guid.NewGuid():N}";
+        var index = CreateCategoryIndex(indexName);
+        RegisterIndex(index);
+
+        await UploadDocuments(indexName,
+            new Dictionary<string, object?> { ["id"] = "1", ["hotelName"] = "Grand Palace", ["category"] = "Luxury" },
+            new Dictionary<string, object?> { ["id"] = "2", ["hotelName"] = "Ocean View", ["category"] = "Resort" },
+            new Dictionary<string, object?> { ["id"] = "3", ["hotelName"] = "Town Stay", ["category"] = "Budget" });
+
+        var response = await _searchService.SearchAsync(indexName, new SearchRequest
+        {
+            Search = "*",
+            Filter = "search.in(category, 'Luxury,Resort')"
+        });
+
+        Assert.Equal(2, response.Value.Count);
+    }
+
+    [Fact]
+    public async Task Filter_SearchIn_WithCustomDelimiter_ReturnsMatchingDocuments()
+    {
+        var indexName = $"searchin-pipe-{Guid.NewGuid():N}";
+        var index = CreateCategoryIndex(indexName);
+        RegisterIndex(index);
+
+        await UploadDocuments(indexName,
+            new Dictionary<string, object?> { ["id"] = "1", ["hotelName"] = "Grand Palace", ["category"] = "Luxury" },
+            new Dictionary<string, object?> { ["id"] = "2", ["hotelName"] = "Ocean View", ["category"] = "Resort" },
+            new Dictionary<string, object?> { ["id"] = "3", ["hotelName"] = "City Central", ["category"] = "Boutique" },
+            new Dictionary<string, object?> { ["id"] = "4", ["hotelName"] = "Town Stay", ["category"] = "Budget" });
+
+        var response = await _searchService.SearchAsync(indexName, new SearchRequest
+        {
+            Search = "*",
+            Filter = "search.in(category, 'Luxury|Resort|Boutique', '|')"
+        });
+
+        Assert.Equal(3, response.Value.Count);
+    }
+
+    [Fact]
+    public async Task Filter_SearchIn_WithMultipleDelimiterCharacters_ReturnsMatchingDocuments()
+    {
+        var indexName = $"searchin-multi-{Guid.NewGuid():N}";
+        var index = CreateCategoryIndex(indexName);
+        RegisterIndex(index);
+
+        await UploadDocuments(indexName,
+            new Dictionary<string, object?> { ["id"] = "1", ["hotelName"] = "Grand Palace", ["category"] = "Luxury" },
+            new Dictionary<string, object?> { ["id"] = "2", ["hotelName"] = "Ocean View", ["category"] = "Resort" },
+            new Dictionary<string, object?> { ["id"] = "3", ["hotelName"] = "City Central", ["category"] = "Boutique" },
+            new Dictionary<string, object?> { ["id"] = "4", ["hotelName"] = "Town Stay", ["category"] = "Budget" });
+
+        var response = await _searchService.SearchAsync(indexName, new SearchRequest
+        {
+            Search = "*",
+            Filter = "search.in(category, 'Luxury|Resort;Boutique', '|;')"
+        });
+
+        Assert.Equal(3, response.Value.Count);
+    }
+
+    public void Dispose()
+    {
+        _luceneManager?.Dispose();
+        if (Directory.Exists(_testDir))
+        {
+            try { Directory.Delete(_testDir, true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
# Description

<!-- Provide a clear and concise description of your changes -->
Fixing custom separator in search.in

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration change
- [ ] ♻️ Refactoring (no functional changes)

## Related Issue

<!-- Link to the issue this PR addresses (if applicable) -->
<!-- Fixes #(issue) -->
Fixes #149 

## Azure AI Search Reference

<!-- If applicable, link to the official Azure AI Search documentation -->
<!-- https://learn.microsoft.com/en-us/azure/search/ -->

According to azure search documentation you can specify your own delimiter: https://learn.microsoft.com/en-us/azure/search/search-query-odata-search-in-function
So the filter from above could be changed to:
search.in(category, 'Luxury|Resort|Boutique', '|')

## Checklist

<!-- Mark completed items with an "x" -->

### Code Quality

- [x] My code follows the [coding standards](../CONTRIBUTING.md#coding-standards) of this project
- [x] I have used meaningful names for variables, methods, and classes
- [x] I have kept methods small and focused (single responsibility)
- [x] I have used async/await for I/O operations where appropriate

### Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run `dotnet test` and all tests pass

### Documentation

- [x] I have updated the documentation as needed
- [x] I have added XML documentation for new public APIs
- [x] I have updated the CHANGELOG.md if applicable

### General

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
