### PR TITLE
Fix missing reference in project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Azure.Core assembly version conflict in solution builds**: Resolved `MSB3277`/`CS1705` caused by mixed `Azure.Core` versions (`1.57.0` and `1.58.0`) across projects. Added an explicit `Azure.Core` `1.58.0` package reference to `AzureAISearchSimulator.Search` so all projects compile against the same assembly version.
 - **DateTimeOffset filters (gt/lt/ge/le) had no effect**: Filtering on `Edm.DateTimeOffset` fields (e.g., `lastRenovationDate gt 2020-01-11`) returned unfiltered results because `long.TryParse` cannot parse date strings. Now parses date values with `DateTimeOffset.TryParse` (assuming UTC) and converts to ticks for the `Int64Range` query.
 - **Facets ignored search query and filters**: Facet counts were computed over the entire index instead of only the documents matching the current search and filter. For example, filtering by `category eq 'Luxury'` still returned facet counts for all categories. Now facets are calculated only from the matching document set (text query + filter combined), matching Azure AI Search behavior where facets reflect the narrowed result set.
 - **Highlight tags not merged for phrase matches**: Phrase searches like `"beautiful spa"` produced `<em>beautiful</em> <em>spa</em>` instead of the Azure AI Search style `<em>beautiful spa</em>`. Adjacent highlight tags are now merged into a single contiguous span.

--- a/src/AzureAISearchSimulator.Search/AzureAISearchSimulator.Search.csproj
+++ b/src/AzureAISearchSimulator.Search/AzureAISearchSimulator.Search.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Core" Version="1.58.0" />
     <PackageReference Include="Lucene.Net" Version="4.8.0-beta00017" />
     <PackageReference Include="Lucene.Net.Analysis.Common" Version="4.8.0-beta00017" />
     <PackageReference Include="Lucene.Net.QueryParser" Version="4.8.0-beta00017" />


### PR DESCRIPTION
# Description

<!-- Provide a clear and concise description of your changes -->
Fix missing reference in project

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration change
- [ ] ♻️ Refactoring (no functional changes)

## Related Issue

<!-- Link to the issue this PR addresses (if applicable) -->
<!-- Fixes #(issue) -->

## Azure AI Search Reference

<!-- If applicable, link to the official Azure AI Search documentation -->
<!-- https://learn.microsoft.com/en-us/azure/search/ -->

## Checklist

<!-- Mark completed items with an "x" -->

### Code Quality

- [x] My code follows the [coding standards](../CONTRIBUTING.md#coding-standards) of this project
- [ ] I have used meaningful names for variables, methods, and classes
- [ ] I have kept methods small and focused (single responsibility)
- [ ] I have used async/await for I/O operations where appropriate

### Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have run `dotnet test` and all tests pass

### Documentation

- [ ] I have updated the documentation as needed
- [ ] I have added XML documentation for new public APIs
- [ ] I have updated the CHANGELOG.md if applicable

### General

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
