### PR TITLE
feat: support facets on complex-type sub-fields (e.g. Tiles/PendingPa…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Facets on complex-type sub-fields (e.g. `Tiles/PendingPaymentCount`)**: Facet expressions can now reference a path into an `Edm.ComplexType` field's sub-fields (value, interval, and metric facets all work). Previously complex fields were only stored as JSON and never indexed field-by-field, so any facet spec naming a sub-field path silently resolved to no field and was skipped. `LuceneDocumentMapper` now indexes each sub-field under a path-qualified Lucene field name (e.g. `"Tiles/PendingPaymentCount"`), and facet field resolution walks the schema's field/sub-field tree instead of a flat top-level lookup. `Collection(Edm.ComplexType)` sub-field faceting (e.g. `Rooms/BaseRate` where `Rooms` is a collection) remains unsupported.
-
-### Added
-
 - **Facet aggregation metrics (`metric:sum`/`min`/`max`/`avg`)**: Facet expressions now support the Azure AI Search preview aggregation syntax `"field,metric:sum"` (whitespace-tolerant, e.g. `"field, metric: sum"`) on numeric facetable fields (`Edm.Int32`, `Edm.Int64`, `Edm.Double`). Each metric returns a single facet bucket containing only that metric (e.g. `{"sum": 40.0}`, `{"min": 60.0}`), computed over documents matching the current search text and filter. Also supports the `default:` parameter to substitute a value for documents missing the field (e.g. `"field,metric:sum,default:0"`). The same field can be requested with multiple metrics or alongside a regular value/interval facet in one query. Azure's `cardinality` metric and `precisionThreshold` parameter are not supported.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Facets on complex-type sub-fields (e.g. `Tiles/PendingPaymentCount`)**: Facet expressions can now reference a path into an `Edm.ComplexType` field's sub-fields (value, interval, and metric facets all work). Previously complex fields were only stored as JSON and never indexed field-by-field, so any facet spec naming a sub-field path silently resolved to no field and was skipped. `LuceneDocumentMapper` now indexes each sub-field under a path-qualified Lucene field name (e.g. `"Tiles/PendingPaymentCount"`), and facet field resolution walks the schema's field/sub-field tree instead of a flat top-level lookup. `Collection(Edm.ComplexType)` sub-field faceting (e.g. `Rooms/BaseRate` where `Rooms` is a collection) remains unsupported.
+
+### Added
+
 - **Facet aggregation metrics (`metric:sum`/`min`/`max`/`avg`)**: Facet expressions now support the Azure AI Search preview aggregation syntax `"field,metric:sum"` (whitespace-tolerant, e.g. `"field, metric: sum"`) on numeric facetable fields (`Edm.Int32`, `Edm.Int64`, `Edm.Double`). Each metric returns a single facet bucket containing only that metric (e.g. `{"sum": 40.0}`, `{"min": 60.0}`), computed over documents matching the current search text and filter. Also supports the `default:` parameter to substitute a value for documents missing the field (e.g. `"field,metric:sum,default:0"`). The same field can be requested with multiple metrics or alongside a regular value/interval facet in one query. Azure's `cardinality` metric and `precisionThreshold` parameter are not supported.
 
 ### Fixed

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -349,15 +349,17 @@ Supported:
 
 - Value facets with `count:N`
 - Interval facets with `interval:N` (numeric fields)
-- Aggregation metrics `sum`, `min`, `max`, `avg` (top-level `Edm.Int32`, `Edm.Int64`, `Edm.Double` fields)
+- Aggregation metrics `sum`, `min`, `max`, `avg` (`Edm.Int32`, `Edm.Int64`, `Edm.Double` fields, including sub-fields of a complex type)
 - `default:` missing-value substitution for the aggregation metrics above (numeric default only)
+- Facets on `Edm.ComplexType` sub-fields (e.g. `Tiles/PendingPaymentCount`) — sub-fields are indexed field-by-field under a path-qualified name
 
 Not supported:
 
 - The `cardinality` aggregation metric (and its `precisionThreshold` parameter)
 - `sort`, `values`, and `timeoffset` facet parameters
 - Facet hierarchies (`>` and `;` operators) and facet filters (`includeTermFilter` / `excludeTermFilter`)
-- Facets on complex-type sub-fields (e.g. `Rooms/BaseRate`) — complex types are not indexed field-by-field
+- Facets on `Collection(Edm.ComplexType)` sub-fields (e.g. `Rooms/BaseRate` where `Rooms` is a collection) — only non-collection complex types are indexed field-by-field
+- `$filter`/`$orderby` on complex-type sub-fields — only facets resolve field paths today
 
 ## Security Limitations
 

--- a/src/AzureAISearchSimulator.Search/LuceneDocumentMapper.cs
+++ b/src/AzureAISearchSimulator.Search/LuceneDocumentMapper.cs
@@ -158,6 +158,14 @@ public static class LuceneDocumentMapper
                 fields.Add(new StoredField(field.Name, JsonSerializer.Serialize(value)));
                 break;
 
+            case "edm.complextype":
+                // Complex fields are not indexed as a single value. Instead, each sub-field
+                // is indexed under a path-qualified name (e.g. "Tiles/PendingPaymentCount"),
+                // matching the OData path syntax used in $filter/$orderby/facet expressions
+                // and the field-path convention already used for scoring profiles.
+                fields.AddRange(CreateComplexFields(field, value, normalizers, charFilters));
+                break;
+
             default:
                 // Unknown type - store as JSON string
                 fields.Add(new StoredField(field.Name, JsonSerializer.Serialize(value)));
@@ -384,6 +392,90 @@ public static class LuceneDocumentMapper
         }
 
         return fields;
+    }
+
+    /// <summary>
+    /// Indexes the sub-fields of an Edm.ComplexType field. Each sub-field is delegated back
+    /// to <see cref="CreateLuceneFields"/> under a path-qualified name (e.g. "Tiles/PendingPaymentCount"),
+    /// so it gets exactly the same filterable/sortable/facetable Lucene field shapes a top-level
+    /// field of that type would get. Document retrieval is served from the parent document's
+    /// "_raw_json" regardless of what gets stored here.
+    /// </summary>
+    private static IEnumerable<IIndexableField> CreateComplexFields(
+        SearchField field,
+        object value,
+        IEnumerable<CustomNormalizer>? normalizers,
+        IEnumerable<CustomCharFilter>? charFilters)
+    {
+        var fields = new List<IIndexableField>();
+
+        if (field.Fields == null || field.Fields.Count == 0)
+        {
+            return fields;
+        }
+
+        var nestedValues = ExtractComplexObjectValue(value);
+        if (nestedValues == null)
+        {
+            return fields;
+        }
+
+        foreach (var subField in field.Fields)
+        {
+            if (!nestedValues.TryGetValue(subField.Name, out var subValue) || subValue == null)
+            {
+                continue;
+            }
+
+            var qualifiedField = WithQualifiedName(subField, field.Name + "/" + subField.Name);
+            fields.AddRange(CreateLuceneFields(qualifiedField, subValue, normalizers, charFilters));
+        }
+
+        return fields;
+    }
+
+    /// <summary>
+    /// Clones a sub-field definition with its Lucene field name replaced by the full path from
+    /// the complex-type root, keeping all query-relevant attributes (type, searchable/filterable/
+    /// sortable/facetable, retrievable, normalizer, nested sub-fields for multi-level complex
+    /// types). Retrievable is kept (rather than forced off) because the metric aggregation facets
+    /// (sum/min/max/avg) read their per-document value from the field's *stored* Lucene value,
+    /// not from doc values - dropping it would silently zero out those aggregations. The
+    /// resulting duplicate storage (also present in the parent's "_raw_json") is otherwise unused.
+    /// </summary>
+    private static SearchField WithQualifiedName(SearchField field, string qualifiedName)
+    {
+        return new SearchField
+        {
+            Name = qualifiedName,
+            Type = field.Type,
+            Key = false,
+            Searchable = field.Searchable,
+            Filterable = field.Filterable,
+            Sortable = field.Sortable,
+            Facetable = field.Facetable,
+            Retrievable = field.Retrievable,
+            Normalizer = field.Normalizer,
+            Fields = field.Fields
+        };
+    }
+
+    /// <summary>
+    /// Extracts a complex field's value as a name/value map, regardless of whether it arrived
+    /// as a JsonElement object (documents submitted over HTTP) or a plain Dictionary (documents
+    /// constructed directly in-process, e.g. by tests or internal callers).
+    /// </summary>
+    private static Dictionary<string, object?>? ExtractComplexObjectValue(object value)
+    {
+        switch (value)
+        {
+            case Dictionary<string, object?> dict:
+                return dict;
+            case JsonElement je when je.ValueKind == JsonValueKind.Object:
+                return je.EnumerateObject().ToDictionary(p => p.Name, p => (object?)p.Value);
+            default:
+                return null;
+        }
     }
 
     private static IEnumerable<IIndexableField> CreateCollectionStringFields(

--- a/src/AzureAISearchSimulator.Search/SearchService.cs
+++ b/src/AzureAISearchSimulator.Search/SearchService.cs
@@ -1278,6 +1278,39 @@ public class SearchService : ISearchService
     }
 
     /// <summary>
+    /// Resolves a (possibly path-qualified) facet field name against the schema's field tree,
+    /// descending into a complex-type field's sub-fields for each "/"-separated segment after
+    /// the first (e.g. "Tiles/PendingPaymentCount" resolves "Tiles" at the top level, then
+    /// "PendingPaymentCount" within Tiles' sub-fields). Returns null if any segment doesn't
+    /// resolve, or if a non-final segment isn't a complex-type field with sub-fields.
+    /// canonicalFieldName is rebuilt from the schema's own casing for each segment, since Lucene
+    /// field names are case-sensitive and must match how LuceneDocumentMapper indexed them.
+    /// </summary>
+    private static SearchField? ResolveFieldByPath(List<SearchField> topLevelFields, string path, out string canonicalFieldName)
+    {
+        var segments = path.Split('/');
+        var candidates = topLevelFields;
+        SearchField? current = null;
+        var canonicalSegments = new List<string>(segments.Length);
+
+        foreach (var segment in segments)
+        {
+            current = candidates?.FirstOrDefault(f => f.Name.Equals(segment, StringComparison.OrdinalIgnoreCase));
+            if (current == null)
+            {
+                canonicalFieldName = path;
+                return null;
+            }
+
+            canonicalSegments.Add(current.Name);
+            candidates = current.Fields;
+        }
+
+        canonicalFieldName = string.Join("/", canonicalSegments);
+        return current;
+    }
+
+    /// <summary>
     /// Calculates facets for the search results.
     /// Facets are computed only over documents matching the combined text + filter query.
     /// </summary>
@@ -1307,19 +1340,16 @@ public class SearchService : ISearchService
             var interval = parsed.Interval;
             var metric = parsed.Metric;
 
-            // Verify field is facetable
-            var field = schema.Fields.FirstOrDefault(f =>
-                f.Name.Equals(fieldName, StringComparison.OrdinalIgnoreCase));
+            // Verify field is facetable. fieldName may be a path into a complex-type field
+            // (e.g. "Tiles/PendingPaymentCount"), so resolve it by walking the schema's
+            // field/sub-field tree rather than a flat top-level lookup.
+            var field = ResolveFieldByPath(schema.Fields, fieldName, out var canonicalFieldName);
 
             if (field == null || field.Facetable != true)
             {
                 _logger.LogWarning("Field '{FieldName}' is not facetable, skipping", fieldName);
                 continue;
             }
-
-            // Lucene field names are case-sensitive, so downstream reads and the response
-            // dictionary key must use the schema's canonical casing, not the request's.
-            var canonicalFieldName = field.Name;
 
             List<FacetResult>? results;
             if (metric != null)

--- a/src/AzureAISearchSimulator.Search/SearchService.cs
+++ b/src/AzureAISearchSimulator.Search/SearchService.cs
@@ -1293,9 +1293,9 @@ public class SearchService : ISearchService
         SearchField? current = null;
         var canonicalSegments = new List<string>(segments.Length);
 
-        foreach (var segment in segments)
+        for (var i = 0; i < segments.Length; i++)
         {
-            current = candidates?.FirstOrDefault(f => f.Name.Equals(segment, StringComparison.OrdinalIgnoreCase));
+            current = candidates?.FirstOrDefault(f => f.Name.Equals(segments[i], StringComparison.OrdinalIgnoreCase));
             if (current == null)
             {
                 canonicalFieldName = path;
@@ -1303,7 +1303,20 @@ public class SearchService : ISearchService
             }
 
             canonicalSegments.Add(current.Name);
-            candidates = current.Fields;
+
+            var isLastSegment = i == segments.Length - 1;
+            if (!isLastSegment)
+            {
+                // Only Edm.ComplexType sub-fields are indexed by LuceneDocumentMapper;
+                // Collection(Edm.ComplexType) sub-fields are not, so don't descend into them.
+                if (current.Type != SearchFieldDataType.ComplexType)
+                {
+                    canonicalFieldName = path;
+                    return null;
+                }
+
+                candidates = current.Fields;
+            }
         }
 
         canonicalFieldName = string.Join("/", canonicalSegments);

--- a/tests/AzureAISearchSimulator.Integration.Tests/FacetIntegrationTests.cs
+++ b/tests/AzureAISearchSimulator.Integration.Tests/FacetIntegrationTests.cs
@@ -757,6 +757,169 @@ public class FacetIntegrationTests : IDisposable
         Assert.Equal(1, facets.Single(f => f.Value?.ToString() == "Budget").Count);
     }
 
+    [Fact]
+    public async Task Facets_OnComplexTypeSubField_ValueFacet_ReturnsFacetValues()
+    {
+        var indexName = $"facet-complex-value-{Guid.NewGuid():N}";
+        var index = new SearchIndex
+        {
+            Name = indexName,
+            Fields = new List<SearchField>
+            {
+                new() { Name = "id", Type = "Edm.String", Key = true },
+                new()
+                {
+                    Name = "Tiles",
+                    Type = "Edm.ComplexType",
+                    Fields = new List<SearchField>
+                    {
+                        new() { Name = "PendingPaymentCount", Type = "Edm.Int32", Facetable = true, Filterable = true },
+                        new() { Name = "Status", Type = "Edm.String", Facetable = true, Filterable = true }
+                    }
+                }
+            }
+        };
+        RegisterIndex(index);
+
+        await UploadDocuments(indexName,
+            new Dictionary<string, object?> { ["id"] = "1", ["Tiles"] = new Dictionary<string, object?> { ["PendingPaymentCount"] = 3, ["Status"] = "Open" } },
+            new Dictionary<string, object?> { ["id"] = "2", ["Tiles"] = new Dictionary<string, object?> { ["PendingPaymentCount"] = 0, ["Status"] = "Closed" } },
+            new Dictionary<string, object?> { ["id"] = "3", ["Tiles"] = new Dictionary<string, object?> { ["PendingPaymentCount"] = 5, ["Status"] = "Open" } });
+
+        var response = await _searchService.SearchAsync(indexName, new SearchRequest
+        {
+            Search = "*",
+            Facets = new List<string> { "Tiles/Status" }
+        });
+
+        Assert.NotNull(response.SearchFacets);
+        Assert.True(response.SearchFacets.ContainsKey("Tiles/Status"),
+            "Facets should resolve a path into a complex-type field's sub-fields");
+
+        var statusFacets = response.SearchFacets["Tiles/Status"];
+        Assert.Equal(2, statusFacets.Single(f => f.Value?.ToString() == "Open").Count);
+        Assert.Equal(1, statusFacets.Single(f => f.Value?.ToString() == "Closed").Count);
+    }
+
+    [Fact]
+    public async Task Facets_OnComplexTypeSubField_MetricFacet_AggregatesAcrossDocuments()
+    {
+        var indexName = $"facet-complex-metric-{Guid.NewGuid():N}";
+        var index = new SearchIndex
+        {
+            Name = indexName,
+            Fields = new List<SearchField>
+            {
+                new() { Name = "id", Type = "Edm.String", Key = true },
+                new()
+                {
+                    Name = "Tiles",
+                    Type = "Edm.ComplexType",
+                    Fields = new List<SearchField>
+                    {
+                        new() { Name = "PendingPaymentCount", Type = "Edm.Int32", Facetable = true, Filterable = true }
+                    }
+                }
+            }
+        };
+        RegisterIndex(index);
+
+        await UploadDocuments(indexName,
+            new Dictionary<string, object?> { ["id"] = "1", ["Tiles"] = new Dictionary<string, object?> { ["PendingPaymentCount"] = 3 } },
+            new Dictionary<string, object?> { ["id"] = "2", ["Tiles"] = new Dictionary<string, object?> { ["PendingPaymentCount"] = 0 } },
+            new Dictionary<string, object?> { ["id"] = "3", ["Tiles"] = new Dictionary<string, object?> { ["PendingPaymentCount"] = 5 } });
+
+        var response = await _searchService.SearchAsync(indexName, new SearchRequest
+        {
+            Search = "*",
+            Facets = new List<string> { "Tiles/PendingPaymentCount,metric:sum" }
+        });
+
+        Assert.NotNull(response.SearchFacets);
+        Assert.True(response.SearchFacets.ContainsKey("Tiles/PendingPaymentCount"));
+        Assert.Equal(8, response.SearchFacets["Tiles/PendingPaymentCount"].Single().Sum);
+    }
+
+    [Fact]
+    public async Task Facets_OnComplexTypeSubField_WithJsonElementDocument_ReturnsFacetValues()
+    {
+        // Documents submitted over HTTP are deserialized with nested objects as JsonElement
+        // (not Dictionary<string, object?>), since IndexAction's value type is `object?`.
+        // This reproduces that shape directly rather than going through the controller.
+        var indexName = $"facet-complex-jsonelement-{Guid.NewGuid():N}";
+        var index = new SearchIndex
+        {
+            Name = indexName,
+            Fields = new List<SearchField>
+            {
+                new() { Name = "id", Type = "Edm.String", Key = true },
+                new()
+                {
+                    Name = "Tiles",
+                    Type = "Edm.ComplexType",
+                    Fields = new List<SearchField>
+                    {
+                        new() { Name = "PendingPaymentCount", Type = "Edm.Int32", Facetable = true, Filterable = true }
+                    }
+                }
+            }
+        };
+        RegisterIndex(index);
+
+        var doc1 = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object?>>(
+            "{\"id\":\"1\",\"Tiles\":{\"PendingPaymentCount\":3}}")!;
+        var doc2 = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object?>>(
+            "{\"id\":\"2\",\"Tiles\":{\"PendingPaymentCount\":5}}")!;
+
+        Assert.IsType<System.Text.Json.JsonElement>(doc1["Tiles"]);
+
+        await UploadDocuments(indexName, doc1, doc2);
+
+        var response = await _searchService.SearchAsync(indexName, new SearchRequest
+        {
+            Search = "*",
+            Facets = new List<string> { "Tiles/PendingPaymentCount,metric:sum" }
+        });
+
+        Assert.NotNull(response.SearchFacets);
+        Assert.Equal(8, response.SearchFacets["Tiles/PendingPaymentCount"].Single().Sum);
+    }
+
+    [Fact]
+    public async Task Facets_OnComplexTypeSubField_NotFacetable_IsSkipped()
+    {
+        var indexName = $"facet-complex-notfacetable-{Guid.NewGuid():N}";
+        var index = new SearchIndex
+        {
+            Name = indexName,
+            Fields = new List<SearchField>
+            {
+                new() { Name = "id", Type = "Edm.String", Key = true },
+                new()
+                {
+                    Name = "Tiles",
+                    Type = "Edm.ComplexType",
+                    Fields = new List<SearchField>
+                    {
+                        new() { Name = "PendingPaymentCount", Type = "Edm.Int32", Facetable = false, Filterable = true }
+                    }
+                }
+            }
+        };
+        RegisterIndex(index);
+
+        await UploadDocuments(indexName,
+            new Dictionary<string, object?> { ["id"] = "1", ["Tiles"] = new Dictionary<string, object?> { ["PendingPaymentCount"] = 3 } });
+
+        var response = await _searchService.SearchAsync(indexName, new SearchRequest
+        {
+            Search = "*",
+            Facets = new List<string> { "Tiles/PendingPaymentCount" }
+        });
+
+        Assert.True(response.SearchFacets == null || !response.SearchFacets.ContainsKey("Tiles/PendingPaymentCount"));
+    }
+
     public void Dispose()
     {
         _luceneManager?.Dispose();


### PR DESCRIPTION
Complex fields were previously only stored as raw JSON and never indexed field-by-field, so any facet spec naming a sub-field path (e.g. "Tiles/ PendingPaymentCount") silently resolved to no schema field and was skipped, leaving it missing from @search.facets with no error.

LuceneDocumentMapper now indexes each Edm.ComplexType sub-field under a path-qualified Lucene field name, reusing the existing per-type field creation logic. SearchService's facet field resolution walks the schema's field/sub-field tree instead of a flat top-level lookup, so value, interval, and metric (sum/min/max/avg) facets all work on complex sub-fields.

Collection(Edm.ComplexType) sub-field faceting and $filter/$orderby on complex sub-fields remain unsupported (documented in LIMITATIONS.md).

# Description

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration change
- [ ] ♻️ Refactoring (no functional changes)

## Related Issue
https://github.com/Ellerbach/azure-ai-search-simulator/issues/205 
<!-- Link to the issue this PR addresses (if applicable) -->
<!-- Fixes #(issue) -->

## Azure AI Search Reference

<!-- If applicable, link to the official Azure AI Search documentation -->
<!-- https://learn.microsoft.com/en-us/azure/search/ -->

## Checklist

<!-- Mark completed items with an "x" -->

### Code Quality

- [X] My code follows the [coding standards](../CONTRIBUTING.md#coding-standards) of this project
- [X] I have used meaningful names for variables, methods, and classes
- [X] I have kept methods small and focused (single responsibility)
- [X] I have used async/await for I/O operations where appropriate

### Testing

- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X I have run `dotnet test` and all tests pass

### Documentation

- [X] I have updated the documentation as needed
- [X] I have added XML documentation for new public APIs
- [X] I have updated the CHANGELOG.md if applicable

### General

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes or context about the PR -->
